### PR TITLE
fix `week_date_epoch` to represent the begining of each week

### DIFF
--- a/script.js
+++ b/script.js
@@ -67,10 +67,11 @@ function spawn_year(_year, birthday) {
             week_div = document.createElement('div');
             week_div.id = `${_year}-${i+1}-${j+1}`;
             week_div.classList.add('week-cell');
-            week_date_epoch = new Date(`${_year}-${i+1}-${j+1}`).getTime();
+            week_date_epoch = new Date(`${_year}-${i+1}-${(j==0 ? 1 : Math.floor(j*num_days_per_square))}`).getTime();
             today_epoch = new Date().getTime();
 
-            if(week_date_epoch < today_epoch) {
+            // use <= to fill the first week cell on the first day of a month
+            if(week_date_epoch <= today_epoch) {
               week_div.classList.add('filled');
             }
 


### PR DESCRIPTION
The day value (`j+1` in the old version) used to construct `week_date_epoch` should represent the begining of the 1st to 4th weeks in a month. But in the current version it iters from `1` to `4`, representing the 1st to 4th dates of the month. This bug makes all the 4 week cells get filled after the 4th day of a month. It should be fixed in the proposed code :)